### PR TITLE
[Bug]: Fixed histogram update chart reset values issue.

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -430,6 +430,7 @@ export const DataConfigPanelItem = ({
         }
         onChange={(e) => updateHistogramConfig(GROUPBY, type, e.target.value)}
         data-test-subj="valueFieldNumber"
+        min={0}
       />
       <EuiSpacer size="s" />
     </>

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -222,9 +222,9 @@ const getUserConfigs = (
         configOfUser = {
           ...userSelectedConfigs,
           dataConfig: {
-            ...userSelectedConfigs?.dataConfig,
             [GROUPBY]: [{ bucketSize: '', bucketOffset: '' }],
             [AGGREGATIONS]: [],
+            ...userSelectedConfigs?.dataConfig,
           },
         };
         break;


### PR DESCRIPTION
Signed-off-by: Saisanju Sreevalsakumar <saisanju_s@persistent.com>

### Description
Fixed following issues.
1. Histogram values sets to empty after clicking on update chart.
2. Applied minimum limit to 'Bucket Size' & 'Bucket Offset' fields to zero.

### Issues Resolved
https://github.com/opensearch-project/observability/issues/1144